### PR TITLE
Fully-automate development setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: |
+      make clean runtime
+    command: |
+      ./just --help
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+## Hacking on just in Gitpod
+
+If you have a web browser, you can get a fully pre-configured development environment with one click:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/just-js/just)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Just
+# Just [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/just-js/just)
 
 A very small v8 javascript runtime for linux only
 


### PR DESCRIPTION
Hi just! 👋

This tweet https://twitter.com/justjs14/status/1417631887456100354 caught my eye. Here is a PR that fully automates the dev setup of just with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/just-js/just/pull/22)

### What it does

* Comes with all dependencies pre-installed
* Runs make clean runtime ahead-of-time (so you don't need to wait)
* Gives anyone immediate access to the pre-compiled just CLI

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).